### PR TITLE
Switch from Gmail SMTP to SendGrid API for email service

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -55,8 +55,8 @@ CLOUDINARY_API_KEY=<from-cloudinary-console>
 CLOUDINARY_API_SECRET=<from-cloudinary-console>
 ADMIN_EMAILS=admin@example.com
 FRONTEND_URL=https://thursdate.vercel.app
-EMAIL_USER=<your-gmail-address>
-EMAIL_PASSWORD=<gmail-app-password>
+SENDGRID_API_KEY=<your-sendgrid-api-key>
+SENDGRID_FROM_EMAIL=noreply@thursdate.app
 ```
 
 **Generate JWT Secret:**
@@ -64,13 +64,25 @@ EMAIL_PASSWORD=<gmail-app-password>
 node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
 ```
 
-**How to get Gmail App Password:**
-1. Go to https://myaccount.google.com/security
-2. Enable 2-Step Verification if not already enabled
-3. Go to https://myaccount.google.com/apppasswords
-4. Create app password for "Mail"
-5. Copy the 16-character password (no spaces)
-6. Use this as EMAIL_PASSWORD
+**How to get SendGrid API Key:**
+1. Go to https://sendgrid.com/ and create a free account (100 emails/day)
+2. Verify your email address
+3. Go to Settings → API Keys
+4. Click "Create API Key"
+5. Name it "Thursdate Production"
+6. Select "Full Access" or "Restricted Access" with Mail Send permissions
+7. Copy the API key (starts with "SG.")
+8. Use this as SENDGRID_API_KEY
+
+**How to verify sender email:**
+1. In SendGrid dashboard, go to Settings → Sender Authentication
+2. Click "Verify a Single Sender"
+3. Fill in your details with the email you want to use (e.g., noreply@yourdomain.com)
+4. SendGrid will send a verification email
+5. Click the link to verify
+6. Use this email as SENDGRID_FROM_EMAIL
+
+**Note:** SendGrid free tier allows 100 emails/day. For higher volume, upgrade to a paid plan.
 
 **Optional Variables (if using AWS Rekognition for face verification):**
 ```bash

--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -667,6 +667,44 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
@@ -1500,6 +1538,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -2386,14 +2433,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.0.tgz",
-      "integrity": "sha512-xvVJf/f0bzmNpnRIbhCp/IKxaHgJ6QynvUbLXzzMRPG3LDQr5oXkYuw4uDFyFYs8cge8agwwrJAXZsd4hhMquw==",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-rekognition": "^3.983.0",
+        "@sendgrid/mail": "^8.1.6",
         "axios": "^1.13.2",
         "bcrypt": "^6.0.0",
         "cloudinary": "^2.7.0",
@@ -21,7 +22,6 @@
         "multer": "^2.0.2",
         "mysql2": "^3.14.3",
         "node-cron": "^3.0.3",
-        "nodemailer": "^8.0.0",
         "passport": "^0.7.0",
         "socket.io": "^4.8.3"
       }
@@ -687,6 +687,44 @@
       "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sendgrid/client": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
+      "integrity": "sha512-/BHu0hqwXNHr2aLhcXU7RmmlVqrdfrbY9KpaNj00KZHlVOVoRxRVrpOCabIB+91ISXJ6+mLM9vpaVUhK6TwBWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/helpers": "^8.0.0",
+        "axios": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-8.1.6.tgz",
+      "integrity": "sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sendgrid/client": "^8.1.5",
+        "@sendgrid/helpers": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -1522,6 +1560,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -2408,14 +2455,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.0.tgz",
-      "integrity": "sha512-xvVJf/f0bzmNpnRIbhCp/IKxaHgJ6QynvUbLXzzMRPG3LDQr5oXkYuw4uDFyFYs8cge8agwwrJAXZsd4hhMquw==",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   "description": "",
   "dependencies": {
     "@aws-sdk/client-rekognition": "^3.983.0",
+    "@sendgrid/mail": "^8.1.6",
     "axios": "^1.13.2",
     "bcrypt": "^6.0.0",
     "cloudinary": "^2.7.0",
@@ -28,7 +29,6 @@
     "multer": "^2.0.2",
     "mysql2": "^3.14.3",
     "node-cron": "^3.0.3",
-    "nodemailer": "^8.0.0",
     "passport": "^0.7.0",
     "socket.io": "^4.8.3"
   }

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -36,10 +36,10 @@ services:
         sync: false
       - key: ADMIN_EMAILS
         sync: false
-      - key: EMAIL_USER
-        sync: false # Gmail address for sending OTP emails
-      - key: EMAIL_PASSWORD
-        sync: false # Gmail App Password (not regular password)
+      - key: SENDGRID_API_KEY
+        sync: false # SendGrid API Key from sendgrid.com
+      - key: SENDGRID_FROM_EMAIL
+        value: noreply@thursdate.app # Verified sender email in SendGrid
 
 # Note: 
 # - Set 'sync: false' variables manually in Render Dashboard


### PR DESCRIPTION
- Replaced nodemailer with @sendgrid/mail package
- Updated emailService.js to use SendGrid API instead of SMTP
- Removed EMAIL_USER and EMAIL_PASSWORD env vars
- Added SENDGRID_API_KEY and SENDGRID_FROM_EMAIL env vars
- Updated render.yaml with SendGrid configuration
- Updated DEPLOYMENT_GUIDE.md with SendGrid setup instructions
- Updated .env.example with SendGrid variables
- Fixes: OTP emails failing on Render due to SMTP port blocking